### PR TITLE
Fix NULL deref in kernel with certain webcams. #issue 2551

### DIFF
--- a/drivers/usb/core/usb.c
+++ b/drivers/usb/core/usb.c
@@ -273,9 +273,13 @@ EXPORT_SYMBOL_GPL(usb_find_alt_setting);
 struct usb_interface *usb_ifnum_to_if(const struct usb_device *dev,
 				      unsigned ifnum)
 {
-	struct usb_host_config *config = dev->actconfig;
+	struct usb_host_config *config = NULL;
 	int i;
 
+	if (!dev)
+		return NULL;
+	
+	config = dev->actconfig;
 	if (!config)
 		return NULL;
 	for (i = 0; i < config->desc.bNumInterfaces; i++)


### PR DESCRIPTION
Fixing issue with Logitech webcams and NULL deref in kernel.
https://github.com/raspberrypi/linux/issues/2551